### PR TITLE
Fix date module dependency resolution

### DIFF
--- a/entity_xliff_ftp.info
+++ b/entity_xliff_ftp.info
@@ -4,5 +4,6 @@ core = 7.x
 configure = admin/config/services/entity-xliff-ftp
 
 dependencies[] = composer_manager
+dependencies[] = date
 dependencies[] = date_api
 dependencies[] = entity_xliff


### PR DESCRIPTION
If you install this module via drush, then try and enable, it fails to find the date module dependency via `date_api`. Simple fix.
